### PR TITLE
Accommodate more flexible formats

### DIFF
--- a/AttributeParser/AttributeParser.vcxproj
+++ b/AttributeParser/AttributeParser.vcxproj
@@ -157,6 +157,7 @@
   </ItemGroup>
   <ItemGroup>
     <Text Include="attributes_test_0.txt" />
+    <Text Include="easy.txt" />
     <Text Include="tags_test_0.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/AttributeParser/AttributeParser.vcxproj.filters
+++ b/AttributeParser/AttributeParser.vcxproj.filters
@@ -32,6 +32,9 @@
     <Text Include="attributes_test_0.txt">
       <Filter>Resource Files</Filter>
     </Text>
+    <Text Include="easy.txt">
+      <Filter>Resource Files</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Attribute.h">

--- a/AttributeParser/attributes_test_0.txt
+++ b/AttributeParser/attributes_test_0.txt
@@ -1,4 +1,4 @@
-<tag1  name = "hello">
+<tag1 name="hello">
 	<tag2>
 		<tag3>
 			<tag4>

--- a/AttributeParser/easy.txt
+++ b/AttributeParser/easy.txt
@@ -1,0 +1,2 @@
+<tag1 name="hello">
+</tag1>


### PR DESCRIPTION
- This accommodates more flexible HTML-like syntax, where the attributes are in the form `<tagName attrName="attrValue">`
- This also replaces amateurish `cerr` error handling with runtime exceptions.

